### PR TITLE
chore(version): bump to 0.2.12 and implement permission handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hikka-forge",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Added permission management for hikka.io access in the popup. The extension now checks for required permissions and shows a UI to request them if not granted. The module loading is now conditional on having the necessary permissions.